### PR TITLE
Get image path from XML file path

### DIFF
--- a/page2img.py
+++ b/page2img.py
@@ -61,10 +61,13 @@ def cli(page, out_dir, level, image_format, page_version, text, font):
 
     #
     # URL or file?
+    dir = os.path.dirname(page.name)
     if validators.url(src_img):
         f = urlopen(src_img)
     elif os.path.exists(src_img):
         f = open(src_img, "rb")
+    elif os.path.exists(f'{dir}/{src_img}'):
+        f = open(f'{dir}/{src_img}', "rb")
     else:
         click.echo("File %s could not be retrieved! Aborting." % src_img, err=True)
         sys.exit(1)


### PR DESCRIPTION
With this patch it is no longer necessary to change the current directory to the directory of the XML file before running page2img.

This improves the usability of that Python script.