### PR TITLE
add packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.[oa]
 *.swp
 *~
+build
+dist
+*.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61.0.0", "wheel"]
+
+[project]
+name = "format-converters"
+version = "0.1"
+authors = [
+    {name = "Frank Wiegand", email = "frank.wiegand@gmail.com"},
+    {name = "Matthias Boenig", email = "matthiasboenig@gmx.net"},
+    {name = "Marius Hug", email = "marius.hug@googlemail.com"},
+    {name = "Kay-Michael Wuerzner", email = "wuerzner@gmail.com"},
+]
+description = "Converters for various file formats used for representing OCR"
+license.file = "LICENSE"
+requires-python = ">=3.8"
+dynamic = ["dependencies"]
+
+[project.scripts]
+page2img = "page2img:cli"
+
+[project.urls]
+Homepage = "https://github.com/OCR-D/format-converters"
+Repository = "https://github.com/OCR-D/format-converters.git"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
+[tool.setuptools]
+py-modules = ["page2img"]
+#package-data = {"*" = ["*.xsl"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0.0", "wheel"]
 
 [project]
 name = "format-converters"
-version = "0.1"
+version = "0.1.0"
 authors = [
     {name = "Frank Wiegand", email = "frank.wiegand@gmail.com"},
     {name = "Matthias Boenig", email = "matthiasboenig@gmx.net"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=61.0.0", "wheel"]
 
 [project]
-name = "format-converters"
+name = "ocrd-format-converters"
 version = "0.1.0"
 authors = [
     {name = "Frank Wiegand", email = "frank.wiegand@gmail.com"},


### PR DESCRIPTION
(not for the XSLTs though – we would need to define a package where to include them as pkg-data, first)

This is supposed to be used by ocr-fileformat to directly install the `page2img` convenience script.